### PR TITLE
First version of serialization_utils package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.1)
+project(serialization_utils)
+
+# Specify C++ Standard
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
+
+# stop build on first error
+string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors")
+
+find_package(catkin REQUIRED)
+
+catkin_package(
+    INCLUDE_DIRS include
+)
+
+include_directories(
+    include
+    ${catkin_INCLUDE_DIRS}
+)
+
+#############
+## Install ##
+#############
+
+# Mark cpp header files for installation
+install(DIRECTORY include/${PROJECT_NAME}/
+    DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+)
+
+
+###########
+## Tests ##
+###########
+
+if (CATKIN_ENABLE_TESTING)
+    find_package(OpenCV REQUIRED)
+    catkin_add_gtest(test_serialize_cvmat test/test_serialize_cvmat.cpp)
+    target_link_libraries(test_serialize_cvmat
+        ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED on)
 # stop build on first error
 string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors")
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS
+    mpi_cmake_modules
+)
+
+search_for_cereal_required()
 
 catkin_package(
     INCLUDE_DIRS include
@@ -17,6 +21,7 @@ catkin_package(
 include_directories(
     include
     ${catkin_INCLUDE_DIRS}
+    ${cereal_INCLUDE_DIRS}
 )
 
 #############
@@ -37,5 +42,5 @@ if (CATKIN_ENABLE_TESTING)
     find_package(OpenCV REQUIRED)
     catkin_add_gtest(test_serialize_cvmat test/test_serialize_cvmat.cpp)
     target_link_libraries(test_serialize_cvmat
-        ${catkin_LIBRARIES} ${OpenCV_LIBRARIES})
+        ${catkin_LIBRARIES} ${cereal_LIBRARIES} ${OpenCV_LIBRARIES})
 endif()

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,38 @@
+This repository contains a collection of files from different sources which are
+provided with different licenses.  See the header of each file for the license
+that is valid for the corresponding file.
+
+For files without an explicit copyright/license note in the header, the below is
+valid.
+
+---
+
+BSD 3-Clause License
+
+Copyright (c) 2020 Max Planck Gesellschaft
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/include/serialization_utils/cereal_cvmat.hpp
+++ b/include/serialization_utils/cereal_cvmat.hpp
@@ -1,0 +1,92 @@
+/**
+ * @file
+ * @brief Serialization functions for serializing `cv::Mat` with cereal.
+ * @author Patrik Huber
+ * @license Apache-2.0
+ * @todo Move this to some "serialization tools" package
+ *
+ * Taken from
+ * https://www.patrikhuber.ch/blog/2015/05/serialising-opencv-matrices-using-boost-and-cereal/
+ */
+
+// Copyright 2015 Patrik Huber
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// NOTE: The code was modified a bit to fix some compiler errors
+
+#pragma once
+
+#include <cereal/archives/binary.hpp>
+#include <opencv2/opencv.hpp>
+
+namespace cereal
+{
+template <class Archive>
+void save(Archive& archive, const cv::Mat& mat)
+{
+    int rows, cols, type;
+    bool continuous;
+
+    rows = mat.rows;
+    cols = mat.cols;
+    type = mat.type();
+    continuous = mat.isContinuous();
+
+    archive(rows, cols, type, continuous);
+
+    if (continuous)
+    {
+        const int data_size = rows * cols * static_cast<int>(mat.elemSize());
+        auto mat_data = cereal::binary_data(mat.ptr(), data_size);
+        archive(mat_data);
+    }
+    else
+    {
+        const int row_size = cols * static_cast<int>(mat.elemSize());
+        for (int i = 0; i < rows; i++)
+        {
+            auto row_data = cereal::binary_data(mat.ptr(i), row_size);
+            archive(row_data);
+        }
+    }
+};
+
+template <class Archive>
+void load(Archive& archive, cv::Mat& mat)
+{
+    int rows, cols, type;
+    bool continuous;
+
+    archive(rows, cols, type, continuous);
+
+    if (continuous)
+    {
+        mat.create(rows, cols, type);
+        const int data_size = rows * cols * static_cast<int>(mat.elemSize());
+        auto mat_data = cereal::binary_data(mat.ptr(), data_size);
+        archive(mat_data);
+    }
+    else
+    {
+        mat.create(rows, cols, type);
+        const int row_size = cols * static_cast<int>(mat.elemSize());
+        for (int i = 0; i < rows; i++)
+        {
+            auto row_data = cereal::binary_data(mat.ptr(i), row_size);
+            archive(row_data);
+        }
+    }
+};
+
+}  // namespace cereal

--- a/include/serialization_utils/cereal_eigen.hpp
+++ b/include/serialization_utils/cereal_eigen.hpp
@@ -1,0 +1,68 @@
+/**
+ * @file
+ * @brief Serialization functions for serializing Eigen matrices and arrays
+ *        with cereal.
+ * @authors Azoth, eudoxos
+ * @date 2020-01-15
+ * @license CC BY-SA 4.0
+ * @todo Move this to some "serialization tools" package.
+ *
+ * Taken from https://stackoverflow.com/a/51944389/2095383 with minor
+ * modifications.
+ */
+#pragma once
+
+#include <Eigen/Eigen>
+#include <cereal/cereal.hpp>
+
+namespace cereal
+{
+template <class Archive, class Derived>
+inline typename std::enable_if<
+    traits::is_output_serializable<BinaryData<typename Derived::Scalar>,
+                                   Archive>::value,
+    void>::type
+save(Archive& archive, const Eigen::PlainObjectBase<Derived>& object)
+{
+    typedef Eigen::PlainObjectBase<Derived> ArrT;
+
+    // only add dimensions to the serialized data when they are dynamic
+    if (ArrT::RowsAtCompileTime == Eigen::Dynamic)
+    {
+        archive(object.rows());
+    }
+    if (ArrT::ColsAtCompileTime == Eigen::Dynamic)
+    {
+        archive(object.cols());
+    }
+
+    archive(binary_data(object.data(),
+                        object.size() * sizeof(typename Derived::Scalar)));
+}
+
+template <class Archive, class Derived>
+inline typename std::enable_if<
+    traits::is_input_serializable<BinaryData<typename Derived::Scalar>,
+                                  Archive>::value,
+    void>::type
+load(Archive& archive, Eigen::PlainObjectBase<Derived>& object)
+{
+    typedef Eigen::PlainObjectBase<Derived> ArrT;
+
+    Eigen::Index rows = ArrT::RowsAtCompileTime, cols = ArrT::ColsAtCompileTime;
+    // information about dimensions are only serialized for dynamic-size types
+    if (rows == Eigen::Dynamic)
+    {
+        archive(rows);
+    }
+    if (cols == Eigen::Dynamic)
+    {
+        archive(cols);
+    }
+
+    object.resize(rows, cols);
+    archive(binary_data(object.data(),
+                        static_cast<std::size_t>(
+                            rows * cols * sizeof(typename Derived::Scalar))));
+}
+}  // namespace cereal

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>serialization_utils</name>
+  <version>0.1.0</version>
+  <description>Utilities for data serialization.</description>
+
+  <maintainer email="felix.widmaier@tue.mpg.de">Felix Widmaier</maintainer>
+  <license>mixed</license>
+  <url type="repository">https://github.com/MPI-IS/serialization_utils</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <test_depend>rosunit</test_depend>
+  <test_depend>libopencv-dev</test_depend>
+  <test_depend>libcereal-dev</test_depend>
+
+  <export>
+  </export>
+</package>

--- a/package.xml
+++ b/package.xml
@@ -10,6 +10,10 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>mpi_cmake_modules</build_depend>
+
+  <depend>libcereal-dev</depend>
+
   <test_depend>rosunit</test_depend>
   <test_depend>libopencv-dev</test_depend>
   <test_depend>libcereal-dev</test_depend>

--- a/test/test_serialize_cvmat.cpp
+++ b/test/test_serialize_cvmat.cpp
@@ -1,0 +1,34 @@
+/**
+ * @file
+ * @brief Test serialization of cv::Mat.
+ * @copyright Copyright (c) 2020, Max Planck Gesellschaft.
+ */
+#include <gtest/gtest.h>
+#include <cereal/archives/binary.hpp>
+#include <serialization_utils/cereal_cvmat.hpp>
+
+TEST(TestSerializeCvMat, serialization)
+{
+    cv::Mat m1, m2;
+    std::stringstream serialized_data;
+
+    {
+        m1 = (cv::Mat_<double>(3, 3) << 1, 2, 3, 4, 5, 6, 7, 8, 9);
+        cereal::BinaryOutputArchive oarchive(serialized_data);
+
+        oarchive(m1);
+    }  // archive goes out of scope, ensuring all contents are flushed
+
+    {
+        cereal::BinaryInputArchive iarchive(serialized_data);
+
+        iarchive(m2);
+        ASSERT_EQ(cv::countNonZero(m1 != m2), 0);
+    }
+}
+
+int main(int argc, char **argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
# Description

This is so far just a collection of header files to use cereal with
Eigen and OpenCV matrices.

- cereal_eigen.hpp is copied from robot_interfaces
- cereal_cvmat.hpp is copied from trifinger_cameras

# How I Tested
By removing the files from robot_interfaces and trifinger_cameras and using the versions from this package instead.