### PR TITLE
setting opencv as a quiet dependencies, and compiling tests only if o…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,21 @@ find_package(catkin REQUIRED COMPONENTS
     mpi_cmake_modules
 )
 
+# OpenCV is an optional dependencies.
+# This package is a header library, so will compile
+# fine without OpenCV installed if
+# no package includes its OpenCV dependant
+# header files
+find_package(OpenCV QUIET)
+
+# sanity check: the line above should have
+# defined the variable OpenCV_FOUND (either to 1 for found
+# or 0 for not found). If if the variable is not declared at all,
+# there is something wrong.
+if(NOT DEFINED OpenCV_FOUND)
+  message(WARNING "serialization utils: failed to detect if OpenCV is installed or not")
+endif(NOT DEFINED OpenCV_FOUND)
+
 search_for_cereal_required()
 
 catkin_package(
@@ -33,13 +48,13 @@ install(DIRECTORY include/${PROJECT_NAME}/
     DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
 )
 
-
 ###########
 ## Tests ##
 ###########
 
-if (CATKIN_ENABLE_TESTING)
-    find_package(OpenCV REQUIRED)
+# tests are run only of OpenCV is found,
+# as the tests include opencv related headers
+if (OpenCV_FOUND)
     catkin_add_gtest(test_serialize_cvmat test/test_serialize_cvmat.cpp)
     target_link_libraries(test_serialize_cvmat
         ${catkin_LIBRARIES} ${cereal_LIBRARIES} ${OpenCV_LIBRARIES})


### PR DESCRIPTION
In CMakeLists.txt, the condition for adding gtests was based on the variable CATKIN_ENABLE_TESTING, switched to OpenCV_FOUND