### PR TITLE
Add gzip wrappers for iostreams

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,8 @@ string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors")
 
 find_package(mpi_cmake_modules REQUIRED)
 find_package(cereal REQUIRED)
+find_package(Boost REQUIRED COMPONENTS iostreams)
+
 
 # OpenCV is an optional dependencies. This package is a header library, so will
 # compile fine without OpenCV installed if no package includes its OpenCV
@@ -57,6 +59,17 @@ target_link_libraries(${PROJECT_NAME} INTERFACE cereal::cereal)
 
 # Export the target.
 list(APPEND all_targets ${PROJECT_NAME})
+
+
+add_library(gzip_iostream src/gzip_iostream.cpp)
+target_include_directories(gzip_iostream PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(gzip_iostream Boost::iostreams)
+# position independent code is needed for usage in pybind11 bindings
+set_property(TARGET gzip_iostream PROPERTY POSITION_INDEPENDENT_CODE ON)
+list(APPEND all_targets gzip_iostream)
 
 #
 # Tests.

--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -8,6 +8,7 @@ if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
   # we do not add the other dependencies because these are header files lib
   find_package(mpi_cmake_modules REQUIRED)
   find_package(cereal REQUIRED)
+  find_package(Boost REQUIRED COMPONENTS iostreams)
 
   # optional dep
   find_package(OpenCV QUIET)
@@ -15,6 +16,7 @@ else()
   # we do not add the other dependencies because these are header files lib
   find_dependency(mpi_cmake_modules REQUIRED)
   find_dependency(cereal REQUIRED)
+  find_dependency(Boost REQUIRED COMPONENTS iostreams)
 
   # optional dep
   find_dependency(OpenCV QUIET)

--- a/include/serialization_utils/gzip_iostream.hpp
+++ b/include/serialization_utils/gzip_iostream.hpp
@@ -1,0 +1,43 @@
+/**
+ * @file
+ * @brief Wrappers for reading/writing gzip-compressed streams.
+ * @copyright 2020, Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <iostream>
+
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+
+namespace serialization_utils
+{
+
+/**
+ * @brief Wrap an input stream with gzip decompression.
+ *
+ * Reads the first two bytes from instream to identify if it actually
+ * gzip-compressed.  If not, the wrapper will not add decompression, so this
+ * works for both compressed and uncompressed streams.
+ *
+ * @param instream  The input stream.
+ *
+ * @return Wrapper with gzip decompression.
+ */
+std::unique_ptr<boost::iostreams::filtering_istream> gzip_istream(
+    std::istream &instream);
+
+/**
+ * @brief Wrap an output stream with gzip compression.
+ *
+ * @param outstream  The output stream
+ * @param compress  If false, do not compress.  Useful to keep the code clean in
+ *     cases where compression can be enabled/disabled by a parameter.
+ *
+ * @return Wrapper with gzip compression.
+ */
+std::unique_ptr<boost::iostreams::filtering_ostream> gzip_ostream(
+    std::ostream &outstream, bool compress = true);
+
+}  // namespace serialization_utils

--- a/src/gzip_iostream.cpp
+++ b/src/gzip_iostream.cpp
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * @brief Wrappers for reading/writing gzip-compressed streams.
+ * @copyright 2020, Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#include <serialization_utils/gzip_iostream.hpp>
+
+namespace serialization_utils
+{
+std::unique_ptr<boost::iostreams::filtering_istream> gzip_istream(
+    std::istream &instream)
+{
+    std::unique_ptr<boost::iostreams::filtering_istream> stream_wrapper =
+        std::make_unique<boost::iostreams::filtering_istream>();
+
+    // Read first two bytes of the file.  If it is a gzip file, they should be
+    // 0x1f and 0x8b.
+    uint8_t byte1 = instream.get();
+    uint8_t byte2 = instream.get();
+
+    // reset pointer to the beginning of the file
+    instream.seekg(0);
+
+    if ((byte1 == 0x1f) && (byte2 == 0x8b))
+    {
+        stream_wrapper->push(boost::iostreams::gzip_decompressor());
+    }
+
+    stream_wrapper->push(instream);
+
+    return stream_wrapper;
+}
+
+std::unique_ptr<boost::iostreams::filtering_ostream> gzip_ostream(
+    std::ostream &outstream, bool compress)
+{
+    std::unique_ptr<boost::iostreams::filtering_ostream> stream_wrapper =
+        std::make_unique<boost::iostreams::filtering_ostream>();
+
+    if (compress)
+    {
+        stream_wrapper->push(boost::iostreams::gzip_compressor());
+    }
+    stream_wrapper->push(outstream);
+
+    return stream_wrapper;
+}
+}  // namespace serialization_utils


### PR DESCRIPTION
# Description

Add a tiny library with two functions `gzip_istream` and `gzip_ostream`
which wrap an i/ostream with a boost filtering stream, adding gzip
(de-)compression.

The istream wrapper first reads the first two bytes of the input to
determine if the input is really gzip-compressed.  If not, no
decompression is added (i.e. the wrapper does nothing).  I'm not sure if
this behaviour (i.e. reading the first bytes, then resetting the
pointer) might cause issues in some cases.  At least for fstreams it
seems to be fine.

The ostream wrapper has an optional argument `compress`.  If set to
false, no compression is added by the wrapper (i.e. it basically does
nothing).  This can be useful to keep the code clean in a setup where
compression can be enabled/disabled by a parameter.

This was moved here from https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/101.

# How I tested
In combination with https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/101.