### PR TITLE
Add utility functions to convert to/from JSON

### DIFF
--- a/Config.cmake.in
+++ b/Config.cmake.in
@@ -14,12 +14,12 @@ if(${CMAKE_VERSION} VERSION_LESS "3.15.0")
   find_package(OpenCV QUIET)
 else()
   # we do not add the other dependencies because these are header files lib
-  find_dependency(mpi_cmake_modules REQUIRED)
-  find_dependency(cereal REQUIRED)
-  find_dependency(Boost REQUIRED COMPONENTS iostreams)
+  find_dependency(mpi_cmake_modules)
+  find_dependency(cereal)
+  find_dependency(Boost COMPONENTS iostreams)
 
   # optional dep
-  find_dependency(OpenCV QUIET)
+  find_package(OpenCV QUIET)
 endif()
 
 check_required_components(@PROJECT_NAME@)

--- a/include/serialization_utils/cereal_cvmat.hpp
+++ b/include/serialization_utils/cereal_cvmat.hpp
@@ -3,7 +3,6 @@
  * @brief Serialization functions for serializing `cv::Mat` with cereal.
  * @author Patrik Huber
  * @license Apache-2.0
- * @todo Move this to some "serialization tools" package
  *
  * Taken from
  * https://www.patrikhuber.ch/blog/2015/05/serialising-opencv-matrices-using-boost-and-cereal/

--- a/include/serialization_utils/cereal_json.hpp
+++ b/include/serialization_utils/cereal_json.hpp
@@ -1,0 +1,84 @@
+/**
+ * @file
+ * @brief Utility functions to easily convert from/to JSON
+ * @copyright 2023, Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <ostream>
+#include <string>
+
+#include <cereal/archives/json.hpp>
+
+namespace serialization_utils
+{
+/**
+ * @brief Serialize object to JSON and write to the given stream.
+ *
+ * @tparam T An arbitrary type that implements a cereal-compatible
+ *      ``serialize()`` method.
+ * @param obj  The object that is serialized.
+ * @param stream  Output stream to which the JSON output is written.
+ */
+template <typename T>
+void to_json_stream(T& obj, std::ostream& stream)
+{
+    cereal::JSONOutputArchive json_out(stream);
+    obj.serialize(json_out);
+}
+
+/**
+ * @brief Create object from JSON stream.
+ *
+ * @tparam T An arbitrary type that implements a cereal-compatible
+ *      ``serialize()`` method.
+ * @param stream  Input stream providing a JSON serialisation of the object.
+ *
+ * @return
+ */
+template <typename T>
+T from_json_stream(std::istream& stream)
+{
+    T obj;
+    {
+        cereal::JSONInputArchive json_in(stream);
+        obj.serialize(json_in);
+    }
+    return obj;
+}
+
+/**
+ * @brief Convert object to JSON.
+ *
+ * @tparam T An arbitrary type that implements a cereal-compatible
+ *      ``serialize()`` method.
+ * @param obj Object to be serialized.
+ *
+ * @return JSON string representing the given object.
+ */
+template <typename T>
+std::string to_json(T& obj)
+{
+    std::stringstream stream;
+    to_json_stream(obj, stream);
+    return stream.str();
+}
+
+/**
+ * @brief Create object from JSON string.
+ *
+ * @tparam T An arbitrary type that implements a cereal-compatible
+ *      ``serialize()`` method.
+ * @param json_str JSON string representing an object of type T.
+ *
+ * @return Object created from the given JSON string.
+ */
+template <typename T>
+T from_json(const std::string& json_str)
+{
+    std::stringstream stream(json_str);
+    return from_json_stream<T>(stream);
+}
+
+}  // namespace serialization_utils


### PR DESCRIPTION
# Description
Simple functions that wrap the code for converting an object to/from a JSON string (or stream) using cereal.

They were implemented in [vicon_transformer](https://github.com/intelligent-soft-robots/vicon_transformer/blob/80d34b7c77821b890666eacdfc9f7ed297f3c2aa/include/vicon_transformer/vicon_receiver.hpp#L19) originally, but since they are very generic, I think it makes more sense to have them here.

This PR also fixes an issue in the CMake config: Optional dependencies should use `find_package` and not `find_dependency` in the Config.cmake.in.  Further, the `REQUIRED` keyword should not be used there.